### PR TITLE
adding :max_age as a parameter for verify

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+    inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-if Mix.env === :test, do: import_config "test.exs"
+if Mix.env() === :test, do: import_config("test.exs")

--- a/lib/bouncer/adapters/redis.ex
+++ b/lib/bouncer/adapters/redis.ex
@@ -16,7 +16,7 @@ defmodule Bouncer.Adapters.Redis do
       {:ok, "UdOnTkNoW"}
   """
   def save(data, key, ttl) do
-    {status, _} = RedixPool.command(~w(SET) ++ [key] ++ [Poison.encode! data])
+    {status, _} = RedixPool.command(~w(SET) ++ [key] ++ [Poison.encode!(data)])
     if ttl, do: expire(key, ttl), else: {status, key}
   end
 
@@ -49,7 +49,7 @@ defmodule Bouncer.Adapters.Redis do
   """
   def get(key) do
     case RedixPool.command(~w(GET) ++ [key]) do
-      {_, nil}  -> {:error, nil}
+      {_, nil} -> {:error, nil}
       {_, data} -> {:ok, Parser.parse!(data)}
     end
   end

--- a/lib/bouncer/email_verification.ex
+++ b/lib/bouncer/email_verification.ex
@@ -23,7 +23,7 @@ defmodule Bouncer.EmailVerification do
   Bouncer.Token.regenerate/4.
   """
   def regenerate(conn, user, ttl \\ 86_400) do
-     Token.regenerate(conn, "email", user, ttl)
+    Token.regenerate(conn, "email", user, ttl)
   end
 
   @doc """

--- a/lib/bouncer/password_reset.ex
+++ b/lib/bouncer/password_reset.ex
@@ -23,7 +23,7 @@ defmodule Bouncer.PasswordReset do
   Bouncer.Token.regenerate/4.
   """
   def regenerate(conn, user, ttl \\ 86_400) do
-     Token.regenerate(conn, "password", user, ttl)
+    Token.regenerate(conn, "password", user, ttl)
   end
 
   @doc """

--- a/lib/bouncer/plugs/authorize.ex
+++ b/lib/bouncer/plugs/authorize.ex
@@ -17,7 +17,7 @@ defmodule Bouncer.Plugs.Authorize do
   connection.
   """
   def call(conn, _) do
-    conn |> put_auth_token |> Session.put_current_user
+    conn |> put_auth_token |> Session.put_current_user()
   end
 
   @doc """

--- a/lib/bouncer/session.ex
+++ b/lib/bouncer/session.ex
@@ -23,7 +23,6 @@ defmodule Bouncer.Session do
   """
   def verify(conn, token), do: Token.verify(conn, "user", token)
 
-
   @doc """
   Saves session data given a key and optional ttl (time-to-live).
   """
@@ -34,7 +33,7 @@ defmodule Bouncer.Session do
   connection.
   """
   def put_current_user(conn) do
-    if Map.has_key? conn.private, :auth_token do
+    if Map.has_key?(conn.private, :auth_token) do
       conn
       |> verify(conn.private.auth_token)
       |> Utility.debug_piped("Auth token verification: ")
@@ -79,8 +78,9 @@ defmodule Bouncer.Session do
       false
   """
   def user_request?(conn, id) do
-    has_current_user = Map.has_key?(conn.private, :current_user) &&
-                       Map.has_key?(conn.private.current_user, "id")
+    has_current_user =
+      Map.has_key?(conn.private, :current_user) && Map.has_key?(conn.private.current_user, "id")
+
     if is_bitstring(id) do
       {id, _} = Integer.parse(id)
       has_current_user && conn.private.current_user["id"] == id

--- a/lib/bouncer/token.ex
+++ b/lib/bouncer/token.ex
@@ -6,6 +6,7 @@ defmodule Bouncer.Token do
   alias Phoenix.Token
 
   def adapter, do: Application.get_env(:bouncer, :adapter)
+  def max_age, do: Application.get_env(:bouncer, :max_age, :infinity)
 
   @doc """
   Generates a token, uses it as a key to save user data to the store, and
@@ -42,7 +43,7 @@ defmodule Bouncer.Token do
   false otherwise.
   """
   def validate([conn, namespace, token]) do
-    case Token.verify(conn, namespace, token) do
+    case Token.verify(conn, namespace, token, max_age) do
       {:ok, _} -> token
       _ -> false
     end

--- a/lib/bouncer/token.ex
+++ b/lib/bouncer/token.ex
@@ -6,7 +6,7 @@ defmodule Bouncer.Token do
   alias Phoenix.Token
 
   def adapter, do: Application.get_env(:bouncer, :adapter)
-  def max_age, do: Application.get_env(:bouncer, :max_age, :infinity)
+  def max_age, do: Application.get_env(:bouncer, :max_age, 86400)
 
   @doc """
   Generates a token, uses it as a key to save user data to the store, and

--- a/lib/bouncer/token.ex
+++ b/lib/bouncer/token.ex
@@ -14,16 +14,16 @@ defmodule Bouncer.Token do
   """
   def generate(conn, namespace, user, ttl) do
     token = Token.sign(conn, namespace, user["id"])
-    case adapter.save(user, token, ttl) do
 
+    case adapter.save(user, token, ttl) do
       {:ok, ^token} ->
         case adapter.add(user["id"], token) do
           {:ok, _} -> {:ok, token}
           response -> response
         end
 
-      response -> response
-
+      response ->
+        response
     end
   end
 
@@ -64,9 +64,10 @@ defmodule Bouncer.Token do
   """
   def delete_all(conn, namespace, id) do
     {_, tokens} = adapter.all(id)
+
     tokens
-    |> Enum.map(&([conn, namespace, &1]))
-    |> Enum.filter_map(&validate/1, fn ([_, _, token]) -> token end)
+    |> Enum.map(&[conn, namespace, &1])
+    |> Enum.filter_map(&validate/1, fn [_, _, token] -> token end)
     |> delete(id)
   end
 

--- a/lib/bouncer/token.ex
+++ b/lib/bouncer/token.ex
@@ -6,7 +6,7 @@ defmodule Bouncer.Token do
   alias Phoenix.Token
 
   def adapter, do: Application.get_env(:bouncer, :adapter)
-  def max_age, do: Application.get_env(:bouncer, :max_age, 86400)
+  def max_age, do: Application.get_env(:bouncer, :max_age, 86_400)
 
   @doc """
   Generates a token, uses it as a key to save user data to the store, and

--- a/lib/bouncer/token.ex
+++ b/lib/bouncer/token.ex
@@ -43,7 +43,7 @@ defmodule Bouncer.Token do
   false otherwise.
   """
   def validate([conn, namespace, token]) do
-    case Token.verify(conn, namespace, token, max_age) do
+    case Token.verify(conn, namespace, token, max_age: max_age) do
       {:ok, _} -> token
       _ -> false
     end

--- a/lib/bouncer/utility.ex
+++ b/lib/bouncer/utility.ex
@@ -8,11 +8,16 @@ defmodule Bouncer.Utility do
   def debug_piped(piped, message \\ nil) do
     if Application.get_env(:logger, :level) === :debug do
       case message do
-        nil -> Logger.debug piped
-        _ -> Logger.debug "#{message} #{inspect piped}"
+        nil ->
+          Logger.debug(piped)
+
+        _ ->
+          Logger.debug(fn ->
+            "#{message} #{inspect(piped)}"
+          end)
       end
     end
+
     piped
   end
-
 end

--- a/lib/bouncer/utility.ex
+++ b/lib/bouncer/utility.ex
@@ -12,9 +12,7 @@ defmodule Bouncer.Utility do
           Logger.debug(piped)
 
         _ ->
-          Logger.debug(fn ->
-            "#{message} #{inspect(piped)}"
-          end)
+          Logger.debug("#{message} #{inspect(piped)}")
       end
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,9 +24,9 @@ defmodule Bouncer.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
-      deps: deps,
-      description: description,
-      package: package
+      deps: deps(),
+      description: description(),
+      package: package()
     ]
   end
 
@@ -49,7 +49,7 @@ defmodule Bouncer.Mixfile do
       {:poolboy, "~> 1.4"},
       {:earmark, "~> 0.1", only: [:dev, :test]},
       {:ex_doc, "~> 0.10", only: [:dev, :test]},
-      {:credo, "~> 0.10", only: [:dev, :test]}
+      {:credo, "~> 0.4", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Bouncer.Mixfile do
   use Mix.Project
 
-  defp package do
+  defp package() do
     [
       files: ["lib", "mix.exs", "README.md", "LICENSE"],
       maintainers: ["Ian Walter"],
@@ -10,20 +10,20 @@ defmodule Bouncer.Mixfile do
     ]
   end
 
-  defp description do
+  defp description() do
     """
     Token-based authorization and session management for Phoenix (Elixir)
     """
   end
 
-  def project do
+  def project() do
     [
       app: :bouncer,
       version: "0.3.0",
       elixir: ">= 1.0.0",
-      elixirc_paths: elixirc_paths(Mix.env),
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps,
       description: description,
       package: package
@@ -31,16 +31,16 @@ defmodule Bouncer.Mixfile do
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/mocks"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp applications(:test), do: [:phoenix, :logger]
   defp applications(_), do: [:logger]
 
-  def application do
-    [mod: {Bouncer, []}, applications: applications(Mix.env)]
+  def application() do
+    [mod: {Bouncer, []}, applications: applications(Mix.env())]
   end
 
-  defp deps do
+  defp deps() do
     [
       {:plug, ">= 1.0.3"},
       {:phoenix, ">= 1.2.1"},
@@ -49,7 +49,7 @@ defmodule Bouncer.Mixfile do
       {:poolboy, "~> 1.4"},
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.10", only: :dev},
-      {:credo, "~> 0.4", only: [:dev, :test]}
+      {:credo, "~> 0.10", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -47,8 +47,8 @@ defmodule Bouncer.Mixfile do
       {:poison, "~> 1.5 or ~> 2.0"},
       {:redix, ">= 0.0.0"},
       {:poolboy, "~> 1.4"},
-      {:earmark, "~> 0.1", only: :dev},
-      {:ex_doc, "~> 0.10", only: :dev},
+      {:earmark, "~> 0.1", only: [:dev, :test]},
+      {:ex_doc, "~> 0.10", only: [:dev, :test]},
       {:credo, "~> 0.10", only: [:dev, :test]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
+ 
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "credo": {:hex, :credo, "0.10.2", "03ad3a1eff79a16664ed42fc2975b5e5d0ce243d69318060c626c34720a49512", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-<<<<<<< HEAD
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
@@ -15,16 +15,4 @@
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm"},
   "redix": {:hex, :redix, "0.10.2", "a9eabf47898aa878650df36194aeb63966d74f5bd69d9caa37babb32dbb93c5d", [:mix], [{:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
-=======
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
-  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
-  "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
-  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.0", "c31af4be22afeeebfaf246592778c8c840e5a1ddc7ca87610c41ccfb160c2c57", [:mix], []},
-  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
-  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "redix": {:hex, :redix, "0.4.0", "c8cfad755252e5441c4119437ba3a8989518af7aa90dbd6f4ff7207b72e4a967", [:mix], [{:connection, "~> 1.0.0", [hex: :connection, optional: false]}]},
->>>>>>> updated credo and added formatting
 }

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "credo": {:hex, :credo, "0.10.2", "03ad3a1eff79a16664ed42fc2975b5e5d0ce243d69318060c626c34720a49512", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+<<<<<<< HEAD
   "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
@@ -14,4 +15,16 @@
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm"},
   "redix": {:hex, :redix, "0.10.2", "a9eabf47898aa878650df36194aeb63966d74f5bd69d9caa37babb32dbb93c5d", [:mix], [{:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.0", "8339bee3fa8b91cb84d14c2935f8ecf399ccd87301ad6da6b71c09553834b2ab", [:rebar3], [], "hexpm"},
+=======
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.12.0", "b774aabfede4af31c0301aece12371cbd25995a21bb3d71d66f5c2fe074c603f", [:mix], [{:earmark, "~> 0.2", [hex: :earmark, optional: false]}]},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
+  "phoenix": {:hex, :phoenix, "1.2.1", "6dc592249ab73c67575769765b66ad164ad25d83defa3492dc6ae269bd2a68ab", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, optional: false]}, {:plug, "~> 1.1", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}]},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.0", "c31af4be22afeeebfaf246592778c8c840e5a1ddc7ca87610c41ccfb160c2c57", [:mix], []},
+  "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
+  "redix": {:hex, :redix, "0.4.0", "c8cfad755252e5441c4119437ba3a8989518af7aa90dbd6f4ff7207b72e4a967", [:mix], [{:connection, "~> 1.0.0", [hex: :connection, optional: false]}]},
+>>>>>>> updated credo and added formatting
 }

--- a/test/adapters/redis_test.exs
+++ b/test/adapters/redis_test.exs
@@ -4,7 +4,7 @@ defmodule Adapters.RedisTest do
   alias Bouncer.RedixPool
 
   setup do
-    RedixPool.command ~w(FLUSHALL)
+    RedixPool.command(~w(FLUSHALL))
     :ok
   end
 

--- a/test/email_verification_test.exs
+++ b/test/email_verification_test.exs
@@ -11,42 +11,42 @@ defmodule EmailVerificationTest do
   doctest Bouncer.Session
 
   setup do
-    RedixPool.command ~w(FLUSHALL)
+    RedixPool.command(~w(FLUSHALL))
     {:ok, conn: %Conn{} |> Conn.put_private(:phoenix_endpoint, MockEndpoint)}
   end
 
   test "email verification token is generated", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = EmailVerification.generate conn, user
+    {:ok, token} = EmailVerification.generate(conn, user)
 
-    assert {:ok, [token]} === Redis.all 1
-    assert {:ok, user} === Redis.get token
+    assert {:ok, [token]} === Redis.all(1)
+    assert {:ok, user} === Redis.get(token)
   end
 
   test "email verification token is regenerated", %{conn: conn} do
     user = %{"id" => 2}
-    {:ok, testToken} = EmailVerification.generate conn, user, 86400
+    {:ok, test_token} = EmailVerification.generate(conn, user, 86400)
     :timer.sleep(1)
-    {:ok, newToken} = EmailVerification.regenerate conn, user, 86400
+    {:ok, new_token} = EmailVerification.regenerate(conn, user, 86400)
 
-    assert {:error, nil} === Redis.get testToken
-    assert {:ok, user} === Redis.get newToken
-    assert {:ok, [newToken]} === Redis.all user["id"]
+    assert {:error, nil} === Redis.get(test_token)
+    assert {:ok, user} === Redis.get(new_token)
+    assert {:ok, [new_token]} === Redis.all(user["id"])
   end
 
   test "valid email verification token is verified", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = EmailVerification.generate conn, user, 86400
-    assert {:ok, user} === EmailVerification.verify conn, token
+    {:ok, token} = EmailVerification.generate(conn, user, 86400)
+    assert {:ok, user} === EmailVerification.verify(conn, token)
   end
 
   test "invalid email verification token is not verified", %{conn: conn} do
-    {:ok, token} = Token.generate conn, "test", %{"id" => 1}, 86400
-    assert {:error, "Invalid token"} === EmailVerification.verify conn, token
+    {:ok, token} = Token.generate(conn, "test", %{"id" => 1}, 86400)
+    assert {:error, "Invalid token"} === EmailVerification.verify(conn, token)
   end
 
   test "email verification token not verified when not stored", %{conn: conn} do
-    token = Phoenix.Token.sign conn, "email", 1
-    assert {:error, nil} === EmailVerification.verify conn, token
+    token = Phoenix.Token.sign(conn, "email", 1)
+    assert {:error, nil} === EmailVerification.verify(conn, token)
   end
 end

--- a/test/password_reset_test.exs
+++ b/test/password_reset_test.exs
@@ -11,42 +11,42 @@ defmodule PasswordResetTest do
   doctest Bouncer.Session
 
   setup do
-    RedixPool.command ~w(FLUSHALL)
+    RedixPool.command(~w(FLUSHALL))
     {:ok, conn: %Conn{} |> Conn.put_private(:phoenix_endpoint, MockEndpoint)}
   end
 
   test "password reset token is generated", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = PasswordReset.generate conn, user
+    {:ok, token} = PasswordReset.generate(conn, user)
 
-    assert {:ok, [token]} === Redis.all 1
-    assert {:ok, user} === Redis.get token
+    assert {:ok, [token]} === Redis.all(1)
+    assert {:ok, user} === Redis.get(token)
   end
 
   test "password reset token is regenerated", %{conn: conn} do
     user = %{"id" => 2}
-    {:ok, testToken} = PasswordReset.generate conn, user, 86400
+    {:ok, test_token} = PasswordReset.generate(conn, user, 86400)
     :timer.sleep(1)
-    {:ok, newToken} = PasswordReset.regenerate conn, user, 86400
+    {:ok, new_token} = PasswordReset.regenerate(conn, user, 86400)
 
-    assert {:error, nil} === Redis.get testToken
-    assert {:ok, user} === Redis.get newToken
-    assert {:ok, [newToken]} === Redis.all user["id"]
+    assert {:error, nil} === Redis.get(test_token)
+    assert {:ok, user} === Redis.get(new_token)
+    assert {:ok, [new_token]} === Redis.all(user["id"])
   end
 
   test "valid password reset token is verified", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = PasswordReset.generate conn, user, 86400
-    assert {:ok, user} === PasswordReset.verify conn, token
+    {:ok, token} = PasswordReset.generate(conn, user, 86400)
+    assert {:ok, user} === PasswordReset.verify(conn, token)
   end
 
   test "invalid password reset token is not verified", %{conn: conn} do
-    {:ok, token} = Token.generate conn, "test", %{"id" => 1}, 86400
-    assert {:error, "Invalid token"} === PasswordReset.verify conn, token
+    {:ok, token} = Token.generate(conn, "test", %{"id" => 1}, 86400)
+    assert {:error, "Invalid token"} === PasswordReset.verify(conn, token)
   end
 
   test "password reset token not verified when not stored", %{conn: conn} do
-    token = Phoenix.Token.sign conn, "password", 1
-    assert {:error, nil} === PasswordReset.verify conn, token
+    token = Phoenix.Token.sign(conn, "password", 1)
+    assert {:error, nil} === PasswordReset.verify(conn, token)
   end
 end

--- a/test/plugs/authorize_test.exs
+++ b/test/plugs/authorize_test.exs
@@ -10,7 +10,7 @@ defmodule Plugs.AuthorizeTest do
   doctest Bouncer.Plugs.Authorize
 
   setup do
-    RedixPool.command ~w(FLUSHALL)
+    RedixPool.command(~w(FLUSHALL))
     {:ok, conn: %Conn{} |> Conn.put_private(:phoenix_endpoint, MockEndpoint)}
   end
 
@@ -22,25 +22,25 @@ defmodule Plugs.AuthorizeTest do
   end
 
   test "no user data is added when bogus auth token received", %{conn: conn} do
-    conn = conn
-    |> Conn.put_req_header("authorization", "Bearer test")
-    |> Authorize.call(nil)
+    conn =
+      conn
+      |> Conn.put_req_header("authorization", "Bearer test")
+      |> Authorize.call(nil)
 
     refute Map.has_key?(conn.private, :current_user)
   end
 
   test "user data is added when correct auth header is specified",
-    %{conn: conn} do
-
+       %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = Session.generate conn, user
+    {:ok, token} = Session.generate(conn, user)
 
-    conn = conn
-    |> Conn.put_req_header("authorization", "Bearer #{token}")
-    |> Bouncer.Plugs.Authorize.call(nil)
+    conn =
+      conn
+      |> Conn.put_req_header("authorization", "Bearer #{token}")
+      |> Bouncer.Plugs.Authorize.call(nil)
 
     assert conn.private.auth_token == token
     assert conn.private.current_user == user
-
   end
 end

--- a/test/session_test.exs
+++ b/test/session_test.exs
@@ -11,48 +11,49 @@ defmodule SessionTest do
   doctest Bouncer.Session
 
   setup do
-    RedixPool.command ~w(FLUSHALL)
+    RedixPool.command(~w(FLUSHALL))
     {:ok, conn: %Conn{} |> Conn.put_private(:phoenix_endpoint, MockEndpoint)}
   end
 
   test "session is generated", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = Session.generate conn, user
+    {:ok, token} = Session.generate(conn, user)
 
-    assert {:ok, [token]} === Redis.all 1
-    assert {:ok, user} === Redis.get token
+    assert {:ok, [token]} === Redis.all(1)
+    assert {:ok, user} === Redis.get(token)
   end
 
   test "current_user can be put into the connection", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = Session.generate conn, user
+    {:ok, token} = Session.generate(conn, user)
 
-    conn = conn
-    |> Conn.put_req_header("authorization", "Bearer #{token}")
-    |> Authorize.put_auth_token
-    |> Session.put_current_user
+    conn =
+      conn
+      |> Conn.put_req_header("authorization", "Bearer #{token}")
+      |> Authorize.put_auth_token()
+      |> Session.put_current_user()
 
     assert conn.private.current_user == user
   end
 
   test "session is destroyed", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = Session.generate conn, user
+    {:ok, token} = Session.generate(conn, user)
 
-    assert {:ok, 1} === Session.destroy token, user["id"]
-    assert {:ok, []} === Redis.all user["id"]
-    assert {:error, nil} === Redis.get token
+    assert {:ok, 1} === Session.destroy(token, user["id"])
+    assert {:ok, []} === Redis.all(user["id"])
+    assert {:error, nil} === Redis.get(token)
   end
 
   test "all user sessions are destroyed", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, tokenOne} = Session.generate conn, user
-    {:ok, tokenTwo} = Session.generate conn, user
+    {:ok, token_one} = Session.generate(conn, user)
+    {:ok, token_two} = Session.generate(conn, user)
 
-    Session.destroy_all conn, user["id"]
+    Session.destroy_all(conn, user["id"])
 
-    assert {:ok, []} === Redis.all 1
-    assert {:error, nil} === Redis.get tokenOne
-    assert {:error, nil} === Redis.get tokenTwo
+    assert {:ok, []} === Redis.all(1)
+    assert {:error, nil} === Redis.get(token_one)
+    assert {:error, nil} === Redis.get(token_two)
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start
+ExUnit.start()

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -8,7 +8,7 @@ defmodule TokenTest do
   alias Bouncer.Adapters.Redis
 
   setup do
-    RedixPool.command ~w(FLUSHALL)
+    RedixPool.command(~w(FLUSHALL))
     {:ok, conn: %Conn{} |> Conn.put_private(:phoenix_endpoint, MockEndpoint)}
   end
 
@@ -16,57 +16,57 @@ defmodule TokenTest do
 
   test "token is generated and url-safe", %{conn: conn} do
     user = %{"id" => 1}
-    assert {:ok, token} = Token.generate conn, "test", user, 86400
-    assert {:ok, user} === Redis.get token
-    assert {:ok, [token]} === Redis.all user["id"]
+    assert {:ok, token} = Token.generate(conn, "test", user, 86400)
+    assert {:ok, user} === Redis.get(token)
+    assert {:ok, [token]} === Redis.all(user["id"])
     assert Regex.match?(~r/^[\.a-zA-Z0-9_-]*$/, token)
   end
 
   test "token is deleted", %{conn: conn} do
     user = %{"id" => 2}
-    {:ok, token} = Token.generate conn, "test", user, 86400
-    Token.delete token, user["id"]
+    {:ok, token} = Token.generate(conn, "test", user, 86400)
+    Token.delete(token, user["id"])
 
-    assert {:error, nil} === Redis.get token
-    assert {:ok, []} === Redis.all user["id"]
+    assert {:error, nil} === Redis.get(token)
+    assert {:ok, []} === Redis.all(user["id"])
   end
 
   test "all tokens of namespace are deleted", %{conn: conn} do
     user = %{"id" => 3}
-    {:ok, testToken} = Token.generate conn, "test", user, 86400
-    {:ok, secondToken} = Token.generate conn, "test", user, 86400
-    {:ok, otherToken} = Token.generate conn, "other", user, 86400
-    Token.delete_all conn, "test", user["id"]
+    {:ok, test_token} = Token.generate(conn, "test", user, 86400)
+    {:ok, second_token} = Token.generate(conn, "test", user, 86400)
+    {:ok, other_token} = Token.generate(conn, "other", user, 86400)
+    Token.delete_all(conn, "test", user["id"])
 
-    assert {:error, nil} === Redis.get testToken
-    assert {:error, nil} === Redis.get secondToken
-    assert {:ok, [otherToken]} === Redis.all user["id"]
+    assert {:error, nil} === Redis.get(test_token)
+    assert {:error, nil} === Redis.get(second_token)
+    assert {:ok, [other_token]} === Redis.all(user["id"])
   end
 
   test "token is regenerated and old tokens are deleted", %{conn: conn} do
     user = %{"id" => 4}
-    {:ok, testToken} = Token.generate conn, "test", user, 86400
+    {:ok, test_token} = Token.generate(conn, "test", user, 86400)
     :timer.sleep(1)
-    {:ok, newToken} = Token.regenerate conn, "test", user, 86400
+    {:ok, new_token} = Token.regenerate(conn, "test", user, 86400)
 
-    assert {:error, nil} === Redis.get testToken
-    assert {:ok, user} === Redis.get newToken
-    assert {:ok, [newToken]} === Redis.all user["id"]
+    assert {:error, nil} === Redis.get(test_token)
+    assert {:ok, user} === Redis.get(new_token)
+    assert {:ok, [new_token]} === Redis.all(user["id"])
   end
 
   test "valid token is verified", %{conn: conn} do
     user = %{"id" => 1}
-    {:ok, token} = Token.generate conn, "test", user, 86400
-    assert {:ok, user} === Token.verify conn, "test", token
+    {:ok, token} = Token.generate(conn, "test", user, 86400)
+    assert {:ok, user} === Token.verify(conn, "test", token)
   end
 
   test "invalid token is not verified", %{conn: conn} do
-    {:ok, token} = Token.generate conn, "test", %{"id" => 1}, 86400
-    assert {:error, "Invalid token"} === Token.verify conn, "other", token
+    {:ok, token} = Token.generate(conn, "test", %{"id" => 1}, 86400)
+    assert {:error, "Invalid token"} === Token.verify(conn, "other", token)
   end
 
   test "token not verified when not stored", %{conn: conn} do
-    token = Phoenix.Token.sign conn, "test", 1
-    assert {:error, nil} === Token.verify conn, "test", token
+    token = Phoenix.Token.sign(conn, "test", 1)
+    assert {:error, nil} === Token.verify(conn, "test", token)
   end
 end


### PR DESCRIPTION
currently without the `:max_age` parameter every `Phoenix.Token.verify` call prints an warning. Issue https://github.com/phoenixframework/phoenix/issues/2868

So added a config parameter `:max_age` ( default `86400` i.e. seconds in a day ) in bouncer which can be used to configure the value.